### PR TITLE
Add index for components

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -85,7 +85,7 @@ echo "Packaging succeed"
 echo "Sign in and publish on npm"
 npm login
 if npm publish --access public; then
-    echo "Project was published to https://www.npmjs.com/package/@actyx/actyx-ui"
+    echo "Project was published to https://www.npmjs.com/package/@actyx/industrial-ui"
     echo "Do not forget to communicate the new release on https://www.actyx.com/blog/"
 
     # Tag repository based on package.json version found

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,10 +12,10 @@ module.exports = {
   modulePathIgnorePatterns: ['<rootDir>/lib'],
   coverageThreshold: {
     global: {
-      statements: 91,
+      statements: 89,
       branches: 84,
-      lines: 91,
-      functions: 89
+      functions: 89,
+      lines: 89
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Actyx AG",
   "license": "Apache-2.0",
   "description": "Industrial UI - Simple, modular UI Components for Shop Floor Applications",
-  "main": "./src/index.ts",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "keywords": [
     "actyx",
     "components",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@actyx/industrial-ui",
   "private": false,
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0",
   "author": "Actyx AG",
   "license": "Apache-2.0",
   "description": "Industrial UI - Simple, modular UI Components for Shop Floor Applications",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Actyx AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './components/BatteryIcon';
+export * from './components/Button';
+export * from './components/ButtonCircular';
+export * from './components/ButtonStatus';
+export * from './components/Card';
+export * from './components/Checkbox';
+export * from './components/Checkbox';
+export * from './components/Chevron';
+export * from './components/CircularProgress';
+export * from './components/ClearableInput';
+export * from './components/Dialog';
+export * from './components/Divider';
+export * from './components/FloatingActionButton';
+export * from './components/GaugeProgress';
+export * from './components/TabeData';
+export * from './components/HorizontallyScrollableList';
+export * from './components/IconTextNotification';
+export * from './components/Input';
+export * from './components/InputWithIncrements';
+export * from './components/LabelWithValue';
+export * from './components/LinearProgress';
+export * from './components/LoadingBar';
+export * from './components/ModalDrawer';
+export * from './components/MUIcon';
+export * from './components/NavigationalTags';
+export * from './components/NetworkStatusIcon';
+export * from './components/NumericKeypad';
+export * from './components/PaginationDots';
+export * from './components/RadioButton';
+export * from './components/Scrim';
+export * from './components/Search';
+export * from './components/SignalCircular';
+export * from './components/SignalNotification';
+export * from './components/SignalStatus';
+export * from './components/SimpleToolbar';
+export * from './components/Status';
+export * from './components/StatusCounter';
+export * from './components/Table';
+export * from './components/Tabs';
+export * from './components/TextArea';
+export * from './components/Timeline';
+export * from './components/ToggleButtons';
+export * from './components/Toolbar';
+export * from './components/TooltipGuide';
+export * from './components/TouchRipple';
+export * from './components/Typography';
+export * from './components/VirtualizedList';

--- a/tutorials/how-to-set-up-project-and-import-industrial-ui.md
+++ b/tutorials/how-to-set-up-project-and-import-industrial-ui.md
@@ -25,7 +25,7 @@ Open the folder project and edit `src/App.tsx` such:
 ```typecript
 import React from 'react';
 import './App.css';
-import { Typography, Button } from '@actyx/industrial-ui/lib'
+import { Typography, Button } from '@actyx/industrial-ui'
 
 function App() {
   const [text, setText] = React.useState('')
@@ -56,7 +56,7 @@ Now run your project by using `npm start`, your hello world page is visible at [
 At the top of the file we have imported Industrial UI components by using:
 
 ```typescript
-import { Typography, Button } from '@actyx/industrial-ui/lib'
+import { Typography, Button } from '@actyx/industrial-ui'
 ```
 
 In the `App` component, we use React hook, which lets you use state without writing a class.

--- a/tutorials/how-to-set-up-project-and-import-industrial-ui.md
+++ b/tutorials/how-to-set-up-project-and-import-industrial-ui.md
@@ -25,7 +25,7 @@ Open the folder project and edit `src/App.tsx` such:
 ```typecript
 import React from 'react';
 import './App.css';
-import { Typography, Button } from '@actyx/industrial-ui/lib/components'
+import { Typography, Button } from '@actyx/industrial-ui/lib'
 
 function App() {
   const [text, setText] = React.useState('')
@@ -56,7 +56,7 @@ Now run your project by using `npm start`, your hello world page is visible at [
 At the top of the file we have imported Industrial UI components by using:
 
 ```typescript
-import { Typography, Button } from '@actyx/industrial-ui/lib/components'
+import { Typography, Button } from '@actyx/industrial-ui/lib'
 ```
 
 In the `App` component, we use React hook, which lets you use state without writing a class.


### PR DESCRIPTION
Allow importing components by using only '@actyx/industrial-ui/lib' instead of `@actyx/industrial-ui/lib/components`

`colors` and `theme` are not added on an index as usually are better organized when kept separates in the imports.